### PR TITLE
fix: patch node-forge ASN.1 vulnerability (CVE-2022-24771/24772/24773)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "eriksjaastad",
   "version": "0.1.0",
   "private": true,
+  "resolutions": {
+    "node-forge": "^1.3.1"
+  },
   "dependencies": {
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5506,9 +5506,10 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-forge@0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
+node-forge@0.7.5, node-forge@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.2.tgz#d0d2659a26eef778bf84d73e7f55c08144ee7750"
+  integrity sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Add yarn resolution to force node-forge to v1.3.1+ which fixes the ASN.1 Validator Desynchronization vulnerability that could lead to signature verification bypass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Forces `node-forge` to >=1.3.1 via Yarn resolutions and updates lockfile to 1.3.2.
> 
> - **Dependencies**:
>   - Add `resolutions` in `package.json` to force `node-forge` to `^1.3.1`.
>   - Update `yarn.lock` to resolve `node-forge` to `1.3.2` (consolidates versions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09494e33f4d6ddeecb08c36d216306d43b4c966a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->